### PR TITLE
Update file_download component example to nest downloaded files under…

### DIFF
--- a/components/files/file_download/file_download.bat
+++ b/components/files/file_download/file_download.bat
@@ -7,7 +7,30 @@ set dc="us"
 set site_id=""
 
 rem ## Settings specific to this script.
+rem # File representations in RDM look like the following
+rem # {
+rem #     "id": "a5a6c65d-6f65-49ca-b5a8-405ae4e2e4e9",
+rem #     "key": [
+rem #         "47fdb852-3d15-481f-b17d-0a8c2dfa6242",
+rem #         "fs::file",
+rem #         "MyFile.txt"
+rem #     ],
+rem #     "value": {
+rem #         "_at": 1662123399568,
+rem #         "_id": "a5a6c65d-6f65-49ca-b5a8-405ae4e2e4e9",
+rem #         "_rev": "134a6553-8523-4aee-8534-db274b946ee5",
+rem #         "_type": "fs::file",
+rem #         "name": "MyFile.txt",
+rem #         "parent": "47fdb852-3d15-481f-b17d-0a8c2dfa6242",
+rem #         "size": 10378,
+rem #         "uuid": "e09b0223-72bc-40f6-a998-2191dda0c67b"
+rem #     }
+rem # }
+rem # 
+rem # provide the ["value"]["uuid"] value for "file_uuid" below to download the file
+rem # additionally provide the ["id"] value for "file_id" below to allow this script to name the file according to ["value"]["name"] 
 set file_uuid=""
+set file_id=""
 
 rem ## Authorization. OAuth credentials are used if the JWT string is empty.
 rem # run `SitelinkFrontend.core.store.getState().app.owner.jwt[0]` in your browser developer console to obtain a JWT.
@@ -22,6 +45,7 @@ python file_download.py ^
     --dc %dc% ^
     --site_id %site_id% ^
     --file_uuid %file_uuid% ^
+    --file_id %file_id% ^
     --jwt %jwt% ^
     --oauth_id %oauth_id% ^
     --oauth_secret %oauth_secret% ^

--- a/components/files/file_download/file_download.sh
+++ b/components/files/file_download/file_download.sh
@@ -7,7 +7,30 @@ dc="us"
 site_id=""
 
 ## Settings specific to this script.
+# File representations in RDM look like the following
+# {
+#     "id": "a5a6c65d-6f65-49ca-b5a8-405ae4e2e4e9",
+#     "key": [
+#         "47fdb852-3d15-481f-b17d-0a8c2dfa6242",
+#         "fs::file",
+#         "MyFile.txt"
+#     ],
+#     "value": {
+#         "_at": 1662123399568,
+#         "_id": "a5a6c65d-6f65-49ca-b5a8-405ae4e2e4e9",
+#         "_rev": "134a6553-8523-4aee-8534-db274b946ee5",
+#         "_type": "fs::file",
+#         "name": "MyFile.txt",
+#         "parent": "47fdb852-3d15-481f-b17d-0a8c2dfa6242",
+#         "size": 10378,
+#         "uuid": "e09b0223-72bc-40f6-a998-2191dda0c67b"
+#     }
+# }
+# 
+# provide the ["value"]["uuid"] value for "file_uuid" below to download the file
+# additionally provide the ["id"] value for "file_id" below to allow this script to name the file according to ["value"]["name"] 
 file_uuid=""
+file_id=""
 
 ## Authorization. OAuth credentials are used if the JWT string is empty.
 # run `SitelinkFrontend.core.store.getState().app.owner.jwt[0]` in your browser developer console to obtain a JWT.
@@ -22,6 +45,7 @@ exec python file_download.py \
     --dc "$dc" \
     --site_id "$site_id" \
     --file_uuid "$file_uuid" \
+    --file_id "$file_id" \
     --jwt "$jwt" \
     --oauth_id "$oauth_id" \
     --oauth_secret "$oauth_secret" \

--- a/components/utils/args.py
+++ b/components/utils/args.py
@@ -91,6 +91,13 @@ arg_file_uuid = {
         "required" : True
     }
 
+arg_file_id = {
+        "arg" : "--file_id",
+        "default" : "",
+        "help" : "The RDM ID of the file as a string.",
+        "required" : True
+    }
+
 arg_file_parent_uuid = {
         "arg" : "--file_parent_uuid",
         "default" : None,


### PR DESCRIPTION
… folders named as a function of the site name and provide the new option of configuring the script with a file_id that will allow the example to query RDM for the file name recorded in Sitelink3D v2 and download the file to the local file system as that name. If not provided, the file uuid will be used to name the downloaded file.