### PR TITLE
Add new functionality to datalogger examples. Geodetic WGS84 columns …

### DIFF
--- a/components/transform/transform.py
+++ b/components/transform/transform.py
@@ -2,8 +2,73 @@ import math
 import base64
 import json
 import requests
+import os
+import sys
+
+def path_up_to_last(a_last, a_inclusive=True, a_path=os.path.dirname(os.path.realpath(__file__)), a_sep=os.path.sep):
+    return a_path[:a_path.rindex(a_sep + a_last + a_sep) + (len(a_sep)+len(a_last) if a_inclusive else 0)]
+
+components_dir = path_up_to_last("components")
+
+sys.path.append(os.path.join(components_dir, "utils"))
+from imports import *
+
+for imp in ["file_download", "rdm_pagination_traits", "rdm_list"]:
+    exec(import_cmd(components_dir, imp))
 
 session = requests.Session()
+
+def get_local_grid_to_cartesian_approx_matrix(a_server_url, a_headers, a_site_id, a_transform_rev, a_voxel_extent, a_voxel_list):
+   
+    transform_url = "{0}/transform/v1/site/{1}/transform_rev/{2}/enz_to_ecef_approx_matrix".format(a_server_url, a_site_id, a_transform_rev)
+
+    return session.post(transform_url, headers=a_headers, data=json.dumps({
+        "voxel_extent": a_voxel_extent,
+        "voxels": a_voxel_list,
+    }))
+
+def get_approx_matrices(a_voxel_extent, a_local_points, a_transform_revision, a_site_id, a_server, a_headers):
+
+    voxel_list = []
+    point_index_to_voxel_index = []
+    voxel_hash_to_voxel_list_index = {}
+
+    # Determine the unique voxels we require matrices for to avoid asking for duplicates where multiple points fall within the same voxel.
+
+    for i, point in enumerate(a_local_points):
+
+        voxel ={
+            "i": int(point["e"] / a_voxel_extent),
+            "j": int(point["n"] / a_voxel_extent),
+            "k": int(point["z"] / a_voxel_extent),
+        }
+        voxel_hash = json.dumps(voxel,sort_keys=True)
+
+        voxel_list_index = None
+        if voxel_hash not in voxel_hash_to_voxel_list_index:
+            voxel_list_index = len(voxel_list)
+            voxel_list.append(voxel)
+            voxel_hash_to_voxel_list_index[voxel_hash] = voxel_list_index
+        else:
+            voxel_list_index = voxel_hash_to_voxel_list_index[voxel_hash]
+
+        point_index_to_voxel_index.append(voxel_list_index)
+        
+    approx_matrix_response = get_local_grid_to_cartesian_approx_matrix(a_server.to_url(), a_headers, a_site_id, a_transform_revision, a_voxel_extent, voxel_list)
+    approx_matrices = approx_matrix_response.json()["matrices"]
+
+    return approx_matrices, point_index_to_voxel_index
+
+def cartesian_to_wgs84(a_cartesian_coords):
+
+    Wgs84Spheroid = Spheroid(a_semi_major_axis=6378137.0, a_flattening=1.0 / 298.257223563)
+    wgs84_coords = []
+    for coord in a_cartesian_coords:
+        geodetic = Wgs84Spheroid.cartesianToGeodetic(coord)
+        wgs84_coords.append(geodetic)
+
+    return wgs84_coords
+
 
 def GetTransform(a_server, a_site_id, a_headers):
     start=["transform_gc3"] 
@@ -15,6 +80,159 @@ def GetTransform(a_server, a_site_id, a_headers):
     response = session.get(rdm_url, headers=a_headers, params=params)
     rdm_view_list = response.json()
     return rdm_view_list
+
+# Determine whether this site is localised by searching for an RDM object with id "transform_gc3". This is
+# achieved by querying the _head of RDM rather than relying on a specific RDM view. If localised, also return 
+# the localisation revision
+def get_current_site_localisation(a_server, a_site_id, a_headers):
+    rdm_view_list = GetTransform(a_server=a_server, a_site_id=a_site_id, a_headers=a_headers)
+
+    localised = False
+    transform_revision = ""
+    for obj in rdm_view_list["items"]:
+        try:
+            if obj["id"] == "transform_gc3":
+                localised = True
+                transform_revision = obj["value"]["_rev"]
+                logging.info("Found current site localisation file {} (version {})".format(obj["value"]["file"]["name"],transform_revision))
+                break
+        except KeyError:
+            continue
+    return localised, transform_revision
+
+def wgs84_coord_to_object_list_item(a_wgs_point):
+    obj = {
+        "items" : []
+    }
+    if bool(a_wgs_point):
+
+        try:
+            lat = a_wgs_point["lat"]
+            item_lat = {
+                    "title" : "latitude",
+                    "value" : lat
+                }
+            obj["items"].append(item_lat)
+        except KeyError:
+            pass
+
+        try:
+            lon = a_wgs_point["lon"]
+            item_lon = {
+                    "title" : "longitude",
+                    "value" : lon
+                }
+            obj["items"].append(item_lon)
+        except KeyError:
+            pass
+
+        try:
+            dir = a_wgs_point["dir"]
+            item_dir = {
+                    "title" : "direction",
+                    "value" : dir
+                }
+            obj["items"].append(item_dir)
+        except KeyError:
+            pass
+
+        try:
+            alt = a_wgs_point["alt"]
+            item_alt = {
+                    "title" : "altitude",
+                    "value" : alt
+                }
+            obj["items"].append(item_alt)
+        except KeyError:
+            pass
+
+        try:
+            alt = a_wgs_point["height"]
+            item_alt = {
+                    "title" : "altitude",
+                    "value" : alt
+                }
+            obj["items"].append(item_alt)
+        except KeyError:
+            pass
+
+    return obj    
+
+# Cache local points and transform information to facilitate batch processing of conversions
+# This class handles the management of storing localized coordinates that are typically processed
+# one at a time or line by line. Calling code can use TransformManager to determine approximation
+# matrices for a batch of points and return a converted WGS84 list in one go as if they had been
+# converted one point at a time. This improves the performance of calling code.
+#
+# The transformation of aggregated points also accommodates the transition from one transform revision
+# to another seamlessly.
+class TransformManager():
+    def __init__(self): 
+        self.m_local_machine_point_dict = {} # keyed on transform revision appropriate to the contained points
+
+    def addLocalPoint(self, a_point, a_line_index, transform_info):
+        if not transform_info["revision"] in self.m_local_machine_point_dict:
+            point_list_json = {
+                "point_list" : [],
+                "index_list" : []
+            }
+            self.m_local_machine_point_dict[transform_info["revision"]] = point_list_json
+        self.m_local_machine_point_dict[transform_info["revision"]]["point_list"].append(a_point)
+        self.m_local_machine_point_dict[transform_info["revision"]]["index_list"].append(a_line_index)
+
+    def transform(self, a_server, a_site_id, a_headers):
+        output_list = []
+        for transform_revision in self.m_local_machine_point_dict.keys():
+            point_list_to_transform = self.m_local_machine_point_dict[transform_revision]["point_list"]
+            logging.debug("Transforming {} points recorded during transform revision {}".format(len(point_list_to_transform), transform_revision))
+            approx_matrices, point_index_to_voxel_index = get_approx_matrices(a_voxel_extent=600, a_local_points=point_list_to_transform, a_transform_revision=transform_revision, a_site_id=a_site_id, a_server=a_server, a_headers=a_headers)
+        
+            cartesian_coords = local_grid_to_cartesian(point_list_to_transform, approx_matrices, point_index_to_voxel_index)
+
+            # Lastly we convert the cartesian (ECEF) coordinates into geodetic coordinates. Below converts to WGS84.
+            wgs84_points = cartesian_to_wgs84(a_cartesian_coords=cartesian_coords)
+            object_list = []
+            for i, point in enumerate(wgs84_points):
+                object_list.append( {
+                            "object" : wgs84_coord_to_object_list_item(a_wgs_point=point),
+                            "list_index" : self.m_local_machine_point_dict[transform_revision]["index_list"][i]
+                        }
+                    )
+            output_list.extend(object_list)
+            
+        return output_list
+
+# This class abstracts the collation of WGS84 points natively provided by connected clients and those
+# that are the result of transformation. For efficiency, the transformation is performed once which 
+# means that "local" and "geodetic" coordinates are stored separately by the use of the "add_local_point"
+# and "add_geodetic_point" functions respecitvely. To preserve point ordering, local points are added
+# to a list that is transformed by calculate_geodetic_points but placeholders for these local points are
+# added to m_geodetic_coordinate_list so that the transformed local points can be substitued into the 
+# correct position (index) when available. 
+class GeodeticCoordinateManager():
+    def __init__(self):
+        self.m_geodetic_coordinate_list = []
+        self.m_transform_manager = TransformManager()
+
+    def add_geodetic_point(self, a_point):
+        self.m_geodetic_coordinate_list.append(a_point)
+
+    def add_local_point(self, a_point, transform_info):
+        next_geodetic_coordinate_list_index = len(self.m_geodetic_coordinate_list)
+        self.m_geodetic_coordinate_list.append(None)
+        self.m_transform_manager.addLocalPoint(a_point, next_geodetic_coordinate_list_index, transform_info)
+
+    def calculate_geodetic_points(self, a_server, a_site_id, a_headers):
+        # return the contiguous list of geodetic points, first by submitting the local points for transformation via
+        # the member transformation manager, then by submitting the returned transformed coordinates back into their
+        # spot in the geodetic list using the index tracking used when the local points were cached.
+        transformed_point_list = self.m_transform_manager.transform(a_server, a_site_id, a_headers)
+
+        for point in transformed_point_list:
+            self.m_geodetic_coordinate_list[point["list_index"]] = point["object"]
+
+        return self.m_geodetic_coordinate_list
+
 
 class Spheroid():
     def __init__(self, a_semi_major_axis, a_flattening):
@@ -82,3 +300,33 @@ def local_grid_to_cartesian(points, approx_matrices, point_index_to_matrix_index
                 approx_matrix["rows"][2][3],
         })
     return coords
+
+def query_and_download_site_localization_file_history(a_server_config, a_site_id, a_headers, a_target_dir):
+    page_traits = RdmViewPaginationTraits(a_page_size="500", a_start=["transform_gc3"], a_end=["transform_gc3",None])     
+    ret = query_rdm_by_domain_view(a_server_config=a_server_config, a_site_id=a_site_id, a_domain="sitelink", a_view="_hist", a_headers=a_headers, a_params=page_traits.params())
+
+    logging.info("{} localization objects have been used at this site.".format(len(ret["items"])))
+    for loc in ret["items"]:
+        file_description = "transform file effective from timestamp {}".format(loc["value"]["_at"])
+        logging.info("Downloading {}".format(file_description))
+        target_dir = os.path.join(a_target_dir, file_description)
+        os.makedirs(target_dir, exist_ok=True)
+        with open(os.path.join(target_dir, "metadata.json"),"w") as metadata_file:
+            metadata_file.write(json.dumps(loc["value"], indent=4))
+        download_file(a_server_config=a_server_config, a_site_id=a_site_id, a_file_uuid=loc["value"]["file"]["uuid"], a_headers=a_headers, a_target_dir=target_dir, a_target_name=loc["value"]["file"]["name"])
+
+        for other_file in loc["value"]["other_files"]:
+            download_file(a_server_config=a_server_config, a_site_id=a_site_id, a_file_uuid=other_file["uuid"], a_headers=a_headers, a_target_dir=target_dir, a_target_name=other_file["name"])
+
+    return ret["items"]
+
+def get_transform_info_for_time(a_ms_since_epoch, a_transform_list):
+
+    transform_info = {}
+    for transform in a_transform_list:
+        if a_ms_since_epoch >= transform["value"]["_at"]:
+            transform_info["revision"] = transform["value"]["_rev"]
+            transform_info["file_name"] = transform["value"]["file"]["name"]
+        else:
+            break
+    return transform_info

--- a/components/transform/transform_local_to_wgs84/transform_local_to_wgs84.py
+++ b/components/transform/transform_local_to_wgs84/transform_local_to_wgs84.py
@@ -18,18 +18,6 @@ for imp in ["args", "utils", "get_token", "rdm_pagination_traits", "rdm_list", "
 
 session = requests.Session()
 
-
-def get_local_grid_to_cartesian_approx_matrix(a_server_url, a_headers, a_site_id, a_transform_rev, a_voxel_extent, a_voxel_list):
-   
-    transform_url = "{0}/transform/v1/site/{1}/transform_rev/{2}/enz_to_ecef_approx_matrix".format(a_server_url, a_site_id, a_transform_rev)
-
-    return session.post(transform_url, headers=a_headers, data=json.dumps({
-        "voxel_extent": a_voxel_extent,
-        "voxels": a_voxel_list,
-    }))
-
-
-
 def main():
     script_name = os.path.basename(os.path.realpath(__file__))
 
@@ -45,25 +33,10 @@ def main():
 
     headers = headers_from_jwt_or_oauth(a_jwt=args.jwt, a_client_id=args.oauth_id, a_client_secret=args.oauth_secret, a_scope=args.oauth_scope, a_server_config=server)
  
-    # First we determine whether this site is localised by searching for an RDM object with id "transform_gc3". This is
-    # achieved by querying the _head of RDM rather than relying on a specific RDM view. The result will also contain the transform
+    # First we determine whether this site is localised. If so, the result will also contain the transform
     # version that we will later provide to the transform service in order to convert from local grid (nee) to geodetic (wgs84) space.
-    
-    # We ask RDM for only the object with id of "transform_gc3" with the following start and end parameters
-    rdm_view_list = GetTransform(a_server=server, a_site_id=args.site_id, a_headers=headers)
-
-    localised = False
-    transform_revision = ""
-    for obj in rdm_view_list["items"]:
-        try:
-            if obj["id"] == "transform_gc3":
-                localised = True
-                transform_revision = obj["value"]["_rev"]
-                logging.info("Found site localisation (version {})".format(transform_revision))
-                break
-        except KeyError:
-            continue
-    
+    localised, transform_revision = get_current_site_localisation(a_server=server, a_site_id=args.site_id, a_headers=headers)
+   
     if localised:
 
         # Now we have a localisation version, we can ask the transform service for an approximation matrix and use that
@@ -71,56 +44,22 @@ def main():
         # the get_local_grid_to_cartesian_approx_matrix and local_grid_to_cartesian functions.
         logging.info("Querying transform service for local points in file {}.".format(args.transform_local_position_points_file))
         
-        voxel_extent = 600.0
-        
         with open(args.transform_local_position_points_file, "r") as points_file:
             points = json.loads(points_file.read())
 
-            voxel_list = []
-            point_index_to_voxel_index = []
-            voxel_hash_to_voxel_list_index = {}
-
-            # Determine the unique voxels we require matrices for to avoid asking for duplicates where multiple points 
-            # fall within the same voxel.
-
-            for i, point in enumerate(points):
-
-                voxel ={
-                    "i": int(point["e"] / voxel_extent),
-                    "j": int(point["n"] / voxel_extent),
-                    "k": int(point["z"] / voxel_extent),
-                }
-                voxel_hash = json.dumps(voxel,sort_keys=True)
-
-                voxel_list_index = None
-                if voxel_hash not in voxel_hash_to_voxel_list_index:
-                    voxel_list_index = len(voxel_list)
-                    voxel_list.append(voxel)
-                    voxel_hash_to_voxel_list_index[voxel_hash] = voxel_list_index
-                else:
-                    voxel_list_index = voxel_hash_to_voxel_list_index[voxel_hash]
-
-                point_index_to_voxel_index.append(voxel_list_index)
-                
-            approx_matrix_response = get_local_grid_to_cartesian_approx_matrix(server.to_url(), headers, args.site_id, transform_revision, voxel_extent, voxel_list)
-            approx_matrices = approx_matrix_response.json()["matrices"]
-
-            coords = local_grid_to_cartesian(points, approx_matrices, point_index_to_voxel_index)
-
-            output_dir = make_site_output_dir(a_server_config=server, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_site_id=args.site_id)
+            # Write the converted geodetic (WGS84) coordinates to an output file in a directory named for this site.
+            approx_matrices, point_index_to_voxel_index = get_approx_matrices(a_voxel_extent=600, a_local_points=points, a_transform_revision=transform_revision, a_site_id=args.site_id, a_server=server, a_headers=headers)
+            
+            cartesian_coords = local_grid_to_cartesian(points, approx_matrices, point_index_to_voxel_index)
 
             # Write the converted cartesian (ECEF) coordinates to an output file in a directory named for this site.
+            output_dir = make_site_output_dir(a_server_config=server, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_site_id=args.site_id)
             with open(os.path.join(output_dir, "coords.cartesian.json"), "w") as out_coords_file:
-                out_coords_file.write(json.dumps(coords,sort_keys=True,indent=4))
+                out_coords_file.write(json.dumps(cartesian_coords,sort_keys=True,indent=4))
 
             # Lastly we convert the cartesian coordinates into geodetic coordinates. Below converts to WGS84.
-            Wgs84Spheroid = Spheroid(a_semi_major_axis=6378137.0, a_flattening=1.0 / 298.257223563)
-            wgs84_coords = []
-            for coord in coords:
-                geodetic = Wgs84Spheroid.cartesianToGeodetic(coord)
-                wgs84_coords.append(geodetic)
-
-            # Write the converted geodetic (WGS84) coordinates to an output file in a directory named for this site.
+            wgs84_coords = cartesian_to_wgs84(a_cartesian_coords=cartesian_coords)
+            
             with open(os.path.join(output_dir, "coords.wgs84.json"), "w") as wgs84_coords_file:
                 wgs84_coords_file.write(json.dumps(wgs84_coords,sort_keys=True,indent=4))
 

--- a/workflows/machine_data/historical/datalogger/generic/create_detailed_diagnostic_report/create_detailed_diagnostic_report.py
+++ b/workflows/machine_data/historical/datalogger/generic/create_detailed_diagnostic_report/create_detailed_diagnostic_report.py
@@ -31,7 +31,7 @@ components_dir = os.path.join(path_up_to_last("workflows", False), "components")
 sys.path.append(os.path.join(components_dir, "utils"))
 from imports import *
 
-for imp in ["args", "utils", "get_token", "mfk", "site_detail", "datalogger_utils"]:
+for imp in ["args", "utils", "get_token", "mfk", "site_detail", "datalogger_utils", "transform", "rdm_pagination_traits", "rdm_list"]:
     exec(import_cmd(components_dir, imp))
 
 script_name = os.path.basename(os.path.realpath(__file__))
@@ -48,58 +48,4 @@ logging.info("Running {0} for server={1} dc={2} site={3}".format(os.path.basenam
 
 headers = headers_from_jwt_or_oauth(a_jwt=args.jwt, a_client_id=args.oauth_id, a_client_secret=args.oauth_secret, a_scope=args.oauth_scope, a_server_config=server)
 
-dba_url = "{}/dba/v1/sites/{}/updates?startms={}&endms={}&category=low_freq".format(server.to_url(), args.site_id, args.datalogger_start_ms, args.datalogger_end_ms)
-
-# get the datalogger data
-response = session.get(dba_url, headers=headers)
-response.raise_for_status()
-
-resource_definitions = {}
-assets = {}
-state = {}
-
-output_dir = make_site_output_dir(a_server_config=server, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_site_id=args.site_id)
-resources_dir = os.path.join(output_dir, "resources")
-os.makedirs(resources_dir, exist_ok=True)
-
-report_file_name_temp = os.path.join(output_dir, args.datalogger_output_file_name + ".tmp")
-report_file_temp = open(report_file_name_temp, "w")
-
-# We need to buffer the points of interest we receive from each component of each machine we encounter. This will be output
-# at the end of iteration over the full dataset so that the dynamic column titles can be fully identified over the entire dataset.
-
-point_of_interest_dict = {}
-
-# Main datalogger data processing loop
-header_list = []
-line_count = 0
-for line in response.iter_lines():
-    line_count += 1
-    decoded_json = json.loads(base64.b64decode(line).decode('UTF-8'))
-
-    if decoded_json['type'] == "sitelink::State":
-        UpdateStateForAssetContext(a_state_msg=decoded_json, a_state_dict=state)
-        logging.debug("Found state. Current state: {}".format(json.dumps(state, indent=4)))
-
-    if decoded_json['type'] == "mfk::Replicate":
-        ProcessReplicate(a_decoded_json=decoded_json, a_resource_config_dict=resource_definitions, a_assets_dict=assets, a_state_dict=state, a_resources_dir=resources_dir, a_report_file=report_file_temp, a_header_list=header_list, a_server=server, a_site_id=args.site_id, a_headers=headers)
-
-logging.info("Writing report to {}".format(args.datalogger_output_file_name))
-
-
-report_file_temp.close()
-
-report_file_name = os.path.join(output_dir, args.datalogger_output_file_name)
-report_file = open(report_file_name, "w")
-report_file.write("Machine Type, Device ID, Machine Name, Time (UTC), GPS Mode, Error(H), Error(V), MC Mode, Reverse, Delay Id, Operator Id, Task Id, Surface Name")
-for point_of_interest_name in header_list:
-    report_file.write(", {}".format(point_of_interest_name))
-
-with open(report_file_name_temp, 'r+') as report_file_temp:
-    for line in report_file_temp:
-        report_file.write(line)
-
-report_file_temp.close()
-os.remove(report_file_name_temp)
-
-logging.info("Processed {} lines".format(line_count))
+ProcessDataloggerToCsv(a_server=server, a_site_id=args.site_id, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_datalogger_start_ms=args.datalogger_start_ms, a_datalogger_end_ms=args.datalogger_end_ms, a_datalogger_output_file_name=args.datalogger_output_file_name)

--- a/workflows/machine_data/historical/datalogger/machine_specific/create_dozer_blade_poi_report_with_state/create_dozer_blade_poi_report_with_state.py
+++ b/workflows/machine_data/historical/datalogger/machine_specific/create_dozer_blade_poi_report_with_state/create_dozer_blade_poi_report_with_state.py
@@ -32,7 +32,7 @@ components_dir = os.path.join(path_up_to_last("workflows", False), "components")
 sys.path.append(os.path.join(components_dir, "utils"))
 from imports import *
 
-for imp in ["args", "utils", "get_token", "mfk", "site_detail", "datalogger_utils"]:
+for imp in ["args", "utils", "get_token", "datalogger_utils"]:
     exec(import_cmd(components_dir, imp))
 
 script_name = os.path.basename(os.path.realpath(__file__))
@@ -49,57 +49,4 @@ logging.info("Running {0} for server={1} dc={2} site={3}".format(os.path.basenam
 
 headers = headers_from_jwt_or_oauth(a_jwt=args.jwt, a_client_id=args.oauth_id, a_client_secret=args.oauth_secret, a_scope=args.oauth_scope, a_server_config=server)
 
-dba_url = "{}/dba/v1/sites/{}/updates?startms={}&endms={}&category=low_freq".format(server.to_url(), args.site_id, args.datalogger_start_ms, args.datalogger_end_ms)
-
-# get the datalogger data
-response = session.get(dba_url, headers=headers)
-response.raise_for_status()
-
-resource_definitions = {}
-assets = {}
-state = {}
-
-output_dir = make_site_output_dir(a_server_config=server, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_site_id=args.site_id)
-resources_dir = os.path.join(output_dir, "resources")
-os.makedirs(resources_dir, exist_ok=True)
-
-report_file_name_temp = os.path.join(output_dir, args.datalogger_output_file_name + ".tmp")
-report_file_temp = open(report_file_name_temp, "w")
-
-# We need to buffer the points of interest we receive from each component of each machine we encounter. This will be output
-# at the end of iteration over the full dataset so that the dynamic column titles can be fully identified over the entire dataset.
-
-point_of_interest_dict = {}
-
-# Main datalogger data processing loop
-header_list = []
-line_count = 0
-for line in response.iter_lines():
-    line_count += 1
-    decoded_json = json.loads(base64.b64decode(line).decode('UTF-8'))
-
-    if decoded_json['type'] == "sitelink::State":
-        UpdateStateForAssetContext(a_state_msg=decoded_json, a_state_dict=state)
-        logging.debug("Found state. Current state: {}".format(json.dumps(state, indent=4)))
-
-    if decoded_json['type'] == "mfk::Replicate":
-        ProcessReplicate(a_decoded_json=decoded_json, a_resource_config_dict=resource_definitions, a_assets_dict=assets, a_state_dict=state, a_resources_dir=resources_dir, a_report_file=report_file_temp, a_header_list=header_list, a_server=server, a_site_id=args.site_id, a_headers=headers, a_machine_description_filter="Generic Bulldozer (3DMC)")
-
-logging.info("Writing report to {}".format(args.datalogger_output_file_name))
-
-report_file_temp.close()
-
-report_file_name = os.path.join(output_dir, args.datalogger_output_file_name)
-report_file = open(report_file_name, "w")
-report_file.write("Machine Type, Device ID, Machine Name, Time (UTC), GPS Mode, Error(H), Error(V), MC Mode, Reverse, Delay Id, Operator Id, Task Id, Surface Name")
-for point_of_interest_name in header_list:
-    report_file.write(", {}".format(point_of_interest_name))
-
-with open(report_file_name_temp, 'r+') as report_file_temp:
-    for line in report_file_temp:
-        report_file.write(line)
-
-report_file_temp.close()
-os.remove(report_file_name_temp)
-
-logging.info("Processed {} lines".format(line_count))
+ProcessDataloggerToCsv(a_server=server, a_site_id=args.site_id, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_datalogger_start_ms=args.datalogger_start_ms, a_datalogger_end_ms=args.datalogger_end_ms, a_datalogger_output_file_name=args.datalogger_output_file_name, a_machine_description_filter="Generic Bulldozer (3DMC)")

--- a/workflows/machine_data/historical/datalogger/machine_specific/create_excavator_bucket_poi_report_with_state/create_excavator_bucket_poi_report_with_state.py
+++ b/workflows/machine_data/historical/datalogger/machine_specific/create_excavator_bucket_poi_report_with_state/create_excavator_bucket_poi_report_with_state.py
@@ -32,7 +32,8 @@ components_dir = os.path.join(path_up_to_last("workflows", False), "components")
 sys.path.append(os.path.join(components_dir, "utils"))
 from imports import *
 
-for imp in ["args", "utils", "get_token", "mfk", "site_detail", "datalogger_utils"]:
+#for imp in ["args", "utils", "get_token", "mfk", "site_detail", "datalogger_utils", "transform", "rdm_pagination_traits", "rdm_list"]:
+for imp in ["args", "get_token", "datalogger_utils"]:
     exec(import_cmd(components_dir, imp))
 
 script_name = os.path.basename(os.path.realpath(__file__))
@@ -49,57 +50,4 @@ logging.info("Running {0} for server={1} dc={2} site={3}".format(os.path.basenam
 
 headers = headers_from_jwt_or_oauth(a_jwt=args.jwt, a_client_id=args.oauth_id, a_client_secret=args.oauth_secret, a_scope=args.oauth_scope, a_server_config=server)
 
-dba_url = "{}/dba/v1/sites/{}/updates?startms={}&endms={}&category=low_freq".format(server.to_url(), args.site_id, args.datalogger_start_ms, args.datalogger_end_ms)
-
-# get the datalogger data
-response = session.get(dba_url, headers=headers)
-response.raise_for_status()
-
-resource_definitions = {}
-assets = {}
-state = {}
-
-output_dir = make_site_output_dir(a_server_config=server, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_site_id=args.site_id)
-resources_dir = os.path.join(output_dir, "resources")
-os.makedirs(resources_dir, exist_ok=True)
-
-report_file_name_temp = os.path.join(output_dir, args.datalogger_output_file_name + ".tmp")
-report_file_temp = open(report_file_name_temp, "w")
-
-# We need to buffer the points of interest we receive from each component of each machine we encounter. This will be output
-# at the end of iteration over the full dataset so that the dynamic column titles can be fully identified over the entire dataset.
-
-point_of_interest_dict = {}
-
-# Main datalogger data processing loop
-header_list = []
-line_count = 0
-for line in response.iter_lines():
-    line_count += 1
-    decoded_json = json.loads(base64.b64decode(line).decode('UTF-8'))
-
-    if decoded_json['type'] == "sitelink::State":
-        UpdateStateForAssetContext(a_state_msg=decoded_json, a_state_dict=state)
-        logging.debug("Found state. Current state: {}".format(json.dumps(state, indent=4)))
-
-    if decoded_json['type'] == "mfk::Replicate":
-        ProcessReplicate(a_decoded_json=decoded_json, a_resource_config_dict=resource_definitions, a_assets_dict=assets, a_state_dict=state, a_resources_dir=resources_dir, a_report_file=report_file_temp, a_header_list=header_list, a_server=server, a_site_id=args.site_id, a_headers=headers, a_machine_description_filter="Generic Excavator (3DMC)")
-
-logging.info("Writing report to {}".format(args.datalogger_output_file_name))
-
-report_file_temp.close()
-
-report_file_name = os.path.join(output_dir, args.datalogger_output_file_name)
-report_file = open(report_file_name, "w")
-report_file.write("Machine Type, Device ID, Machine Name, Time (UTC), GPS Mode, Error(H), Error(V), MC Mode, Reverse, Delay Id, Operator Id, Task Id, Surface Name")
-for point_of_interest_name in header_list:
-    report_file.write(", {}".format(point_of_interest_name))
-
-with open(report_file_name_temp, 'r+') as report_file_temp:
-    for line in report_file_temp:
-        report_file.write(line)
-
-report_file_temp.close()
-os.remove(report_file_name_temp)
-
-logging.info("Processed {} lines".format(line_count))
+ProcessDataloggerToCsv(a_server=server, a_site_id=args.site_id, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_datalogger_start_ms=args.datalogger_start_ms, a_datalogger_end_ms=args.datalogger_end_ms, a_datalogger_output_file_name=args.datalogger_output_file_name, a_machine_description_filter="Generic Excavator (3DMC)")

--- a/workflows/machine_data/historical/datalogger/machine_specific/create_roller_drum_poi_report_with_state/create_roller_drum_poi_report_with_state.py
+++ b/workflows/machine_data/historical/datalogger/machine_specific/create_roller_drum_poi_report_with_state/create_roller_drum_poi_report_with_state.py
@@ -17,7 +17,6 @@
 # 2. Cache state information so that the most recent state is available to be output when kinematic updates are received.
 # 3. Process mfk::Replicate packets containing binary encoded kinematic updates, conditioning the data to be output as a CSV line.
 
-
 import logging
 import os
 import sys
@@ -32,7 +31,7 @@ components_dir = os.path.join(path_up_to_last("workflows", False), "components")
 sys.path.append(os.path.join(components_dir, "utils"))
 from imports import *
 
-for imp in ["args", "utils", "get_token", "mfk", "site_detail", "datalogger_utils"]:
+for imp in ["args", "utils", "get_token", "datalogger_utils"]:
     exec(import_cmd(components_dir, imp))
 
 script_name = os.path.basename(os.path.realpath(__file__))
@@ -49,57 +48,4 @@ logging.info("Running {0} for server={1} dc={2} site={3}".format(os.path.basenam
 
 headers = headers_from_jwt_or_oauth(a_jwt=args.jwt, a_client_id=args.oauth_id, a_client_secret=args.oauth_secret, a_scope=args.oauth_scope, a_server_config=server)
 
-dba_url = "{}/dba/v1/sites/{}/updates?startms={}&endms={}&category=low_freq".format(server.to_url(), args.site_id, args.datalogger_start_ms, args.datalogger_end_ms)
-
-# get the datalogger data
-response = session.get(dba_url, headers=headers)
-response.raise_for_status()
-
-resource_definitions = {}
-assets = {}
-state = {}
-
-output_dir = make_site_output_dir(a_server_config=server, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_site_id=args.site_id)
-resources_dir = os.path.join(output_dir, "resources")
-os.makedirs(resources_dir, exist_ok=True)
-
-report_file_name_temp = os.path.join(output_dir, args.datalogger_output_file_name + ".tmp")
-report_file_temp = open(report_file_name_temp, "w")
-
-# We need to buffer the points of interest we receive from each component of each machine we encounter. This will be output
-# at the end of iteration over the full dataset so that the dynamic column titles can be fully identified over the entire dataset.
-
-point_of_interest_dict = {}
-
-# Main datalogger data processing loop
-header_list = []
-line_count = 0
-for line in response.iter_lines():
-    line_count += 1
-    decoded_json = json.loads(base64.b64decode(line).decode('UTF-8'))
-
-    if decoded_json['type'] == "sitelink::State":
-        UpdateStateForAssetContext(a_state_msg=decoded_json, a_state_dict=state)
-        logging.debug("Found state. Current state: {}".format(json.dumps(state, indent=4)))
-
-    if decoded_json['type'] == "mfk::Replicate":
-        ProcessReplicate(a_decoded_json=decoded_json, a_resource_config_dict=resource_definitions, a_assets_dict=assets, a_state_dict=state, a_resources_dir=resources_dir, a_report_file=report_file_temp, a_header_list=header_list, a_server=server, a_site_id=args.site_id, a_headers=headers, a_machine_description_filter="Generic Asphalt Compactor (3DMC)")
-
-logging.info("Writing report to {}".format(args.datalogger_output_file_name))
-
-report_file_temp.close()
-
-report_file_name = os.path.join(output_dir, args.datalogger_output_file_name)
-report_file = open(report_file_name, "w")
-report_file.write("Machine Type, Device ID, Machine Name, Time (UTC), GPS Mode, Error(H), Error(V), MC Mode, Reverse, Delay Id, Operator Id, Task Id, Surface Name")
-for point_of_interest_name in header_list:
-    report_file.write(", {}".format(point_of_interest_name))
-
-with open(report_file_name_temp, 'r+') as report_file_temp:
-    for line in report_file_temp:
-        report_file.write(line)
-
-report_file_temp.close()
-os.remove(report_file_name_temp)
-
-logging.info("Processed {} lines".format(line_count))
+ProcessDataloggerToCsv(a_server=server, a_site_id=args.site_id, a_headers=headers, a_current_dir=os.path.dirname(os.path.realpath(__file__)), a_datalogger_start_ms=args.datalogger_start_ms, a_datalogger_end_ms=args.datalogger_end_ms, a_datalogger_output_file_name=args.datalogger_output_file_name, a_machine_description_filter="Generic Asphalt Compactor (3DMC)")


### PR DESCRIPTION
…latitude, longitude, direction, altitude now appear in all machine specific and generic examples regardless of whether original coordinates sent from the client were localised. Transform revision and the transform source file are now also output. Include names for RDM objects such as user and delay which were previously only tracked by identifier.

This revision demonstrates the established process for deriving the L,L,H from localised position data provided by datalogger. Doing so requires interrogating the site for its localisation history so that the correct approximation matrices can be used appropriate for the localisation that was active at the site when the data was collected. Because localisations can be updated, code can’t simply apply the current one to all historical data.

1.	For each datalogger Replicate providing positions in local coordinates, record the transform revision in use at the time of the replicate and cache that information.
2.	Batch process the local to WGS84 conversion via the transform service at the end of processing for each transform revision active over the time range that datalogger data was provided (too costly to convert a point at a time).
3.	Output the L,L,H to the appropriate columns as would have been natively done for replicates from a haul app.
4.	Also populate a new column to the CSV output that shows the transform revision used for this conversion and the source file so it’s clear to the user what was used to do the conversion and whether or not that changed over the time span.

The end result is a CSV output that can be loaded in Excel. An Excel map add-in to plot the lat, long columns can be used to visualise these columns.

Another important consideration is which local point the user intends to transform for each machine. Because the MFK standard supports multiple points of interest on a machine, there are potentially multiple local points that can be converted. This is obviously machine specific. A dozer and grader for example will report left and right of blade in local coordinates whereas an excavator will report bucket points. Multiple articulation points on the machine body are also available.

This commit uses the “local_position” point as a proxy for the machine position so that a representative position for each machine is converted to L,L,H. Multi component machines contribute only one “local_position” point from Replicate messages to avoid corrupting the single row per replicate paradigm in the CSV output. Otherwise multiple component machines (excavators) would add two local points for every one row added to the CSV output, adding an incorrect row offsets to the WGS84 columns when appended on final output.

To achieve this, this commit introduces a major refactor of similar datalogger to CSV code used in machine specific and generic examples into the one function ProcessDataloggerToCsv. Introduce GeodeticCoordinateManager and TransformManager to manage all WGSS84 output at the final file write.

Refactor the query and download of localization history into query_and_download_site_localization_file_history. Refactored the creation of the object that gets written to the CSV output into wgs84_coord_to_object_list_item and accommodated the two different height keys, alt & height.

Added helper function get_transform_revision_for_time to return the revision of the transform object that was in effect at a specified time at a site.